### PR TITLE
envsetup: Drop buildKernel uni function

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -142,11 +142,6 @@ function buildKernelImage() {
     cd $TOP
 }
 
-function buildKernel() {
-    buildDefconfig
-    buildKernelImage
-}
-
 function checkKernelDirectory() {
     local TOP=$(getTop)
     if [ -d $TOP/$KERNEL_DIR ]; then


### PR DESCRIPTION
* Calling a kernel build altogether breaks the lunch device output during the build